### PR TITLE
Add ZARO (Zaro Coin) — ETH, BSC, Solana, Base

### DIFF
--- a/tokenlists/base.json
+++ b/tokenlists/base.json
@@ -1,0 +1,14 @@
+[
+{
+    "symbol": "ZARO",
+    "name": "Zaro Coin",
+    "address": "0x1d4CeA73e212829d06B9a774d2e06be9DEe5AAB0",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://raw.githubusercontent.com/zarocoin/zarocoin/main/media/logos/ZARO_logo_2D.png",
+    "coingeckoId": "zaro-coin",
+    "listedIn": [
+        "coingecko"
+    ]
+}
+]

--- a/tokenlists/bsc.json
+++ b/tokenlists/bsc.json
@@ -14281,5 +14281,17 @@
             "lifinance",
             "xyfinance"
         ]
-    }
+    },
+    {
+    "symbol": "ZARO",
+    "name": "Zaro Coin",
+    "address": "0xa9D72F6C1490647DF20E8Fad3C136cA6AC42c2fc",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://raw.githubusercontent.com/zarocoin/zarocoin/main/media/logos/ZARO_logo_2D.png",
+    "coingeckoId": "zaro-coin",
+    "listedIn": [
+        "coingecko"
+    ]
+}
 ]

--- a/tokenlists/ethereum.json
+++ b/tokenlists/ethereum.json
@@ -22128,5 +22128,17 @@
             "lifinance",
             "xyfinance"
         ]
-    }
+    },
+    {
+    "symbol": "ZARO",
+    "name": "Zaro Coin",
+    "address": "0xc311FD6DA9686507F33991543d8158EF5FaDd5E7",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/zarocoin/zarocoin/main/media/logos/ZARO_logo_2D.png",
+    "coingeckoId": "zaro-coin",
+    "listedIn": [
+        "coingecko"
+    ]
+}
 ]

--- a/tokenlists/solana.json
+++ b/tokenlists/solana.json
@@ -5158,5 +5158,17 @@
             "coingecko",
             "1sol"
         ]
-    }
+    },
+    {
+    "symbol": "ZARO",
+    "name": "Zaro Coin",
+    "address": "AbzXS6NfGvCtg5B1rqZ1JSfoDHkwTAeEYJkWkHhCe38W",
+    "decimals": 8,
+    "chainId": -1,
+    "logoURI": "https://raw.githubusercontent.com/zarocoin/zarocoin/main/media/logos/ZARO_logo_2D.png",
+    "coingeckoId": "zaro-coin",
+    "listedIn": [
+        "coingecko"
+    ]
+}
 ]


### PR DESCRIPTION
## Add ZARO (Zaro Coin) -- Ethereum, BNB Chain, and Solana

**Token:** Zaro Coin (ZARO)
**CoinGecko ID:** zaro-coin
**Website:** https://www.zarocoin.xyz
**Twitter:** @ZaroCoin_XYZ

### Contracts
| Chain | File | Address | ChainId | Decimals |
|-------|------|---------|---------|----------|
| Ethereum | ethereum.json | `0xc311FD6DA9686507F33991543d8158EF5FaDd5E7` | 1 | 18 |
| BNB Chain | bsc.json | `0xa9D72F6C1490647DF20E8Fad3C136cA6AC42c2fc` | 56 | 18 |
| Solana | solana.json | `AbzXS6NfGvCtg5B1rqZ1JSfoDHkwTAeEYJkWkHhCe38W` | -1 | 8 |

### About ZARO
Zaro Coin is the native token of ZaroVerse, an AI-powered creative studio platform. ZARO launched on Ethereum (ERC-20) and is bridged cross-chain via the Wormhole Token Bridge. The Solana version is a Wormhole-wrapped SPL token (8 decimals).

### Security & Verification
- Blockaid security scan: **confirmed benign on Ethereum and Solana**
- Listed on CoinGecko (ID: zaro-coin)
- Verified on Etherscan, BscScan, and Solana Explorer
- Live liquidity pools on Uniswap V2 (ETH) and PancakeSwap (BSC)
- LP permanently locked in Meteora DLMM (SOL)

### Checklist
- [x] All three addresses verified on-chain
- [x] CoinGecko ID valid: zaro-coin
- [x] Logo URI publicly accessible
- [x] Website live: https://www.zarocoin.xyz
- [x] Blockaid confirmed benign